### PR TITLE
Add customer_id column to users table in Prisma schema 

### DIFF
--- a/backend/typescript/migrations/2022.01.10T17.43.41.create-user-table.ts
+++ b/backend/typescript/migrations/2022.01.10T17.43.41.create-user-table.ts
@@ -28,6 +28,10 @@ export const up: Migration = async ({ context: sequelize }) => {
       type: DataType.ENUM("User", "Admin"),
       allowNull: false,
     },
+    customer_id: {
+      type: DataType.STRING,
+      allowNull: true,
+    },
     createdAt: DataType.DATE,
     updatedAt: DataType.DATE,
   });

--- a/backend/typescript/models/user.model.ts
+++ b/backend/typescript/models/user.model.ts
@@ -14,4 +14,8 @@ export default class User extends Model {
 
   @Column({ type: DataType.ENUM("User", "Admin") })
   role!: Role;
+
+  // Optional customer_id column for Stripe customer ids
+  @Column({ type: DataType.STRING, allowNull: true })
+  customer_id?: string;
 }

--- a/backend/typescript/prisma/migrations/20240618011128_add_customer_id/migration.sql
+++ b/backend/typescript/prisma/migrations/20240618011128_add_customer_id/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "customerID" TEXT;

--- a/backend/typescript/prisma/migrations/20240618012032_npx_prisma_studio/migration.sql
+++ b/backend/typescript/prisma/migrations/20240618012032_npx_prisma_studio/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `customerID` on the `User` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "customerID",
+ADD COLUMN     "customer_id" TEXT;

--- a/backend/typescript/prisma/schema.prisma
+++ b/backend/typescript/prisma/schema.prisma
@@ -22,6 +22,7 @@ model User {
   updatedAt    DateTime?
   role         RoleType
   donations    Donation[]
+  customer_id  String?                                                                                                             
 }
 
 enum RoleType{


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Add customer_id column to users table](https://www.notion.so/uwblueprintexecs/add-customer_id-column-to-users-table-350168fc37a04f3f98e6e2b64e655b0d?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Edited the Prisma schema and applied the migration, allowing for Stripe customer ids to be stored.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Run the Prisma using the instructions in the README.
2. There should be a new column called `customer_id`.
3. Create a new user and fill in the `customer_id` to ensure that there are no errors.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Nothing — hope that everything goes well!


## Checklist
- [X] My PR name is descriptive and in imperative tense
- [X] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [X] I have run the appropriate linter(s)
- [X] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
