### PR TITLE
change donations table to display cause name instead of cause id

### DIFF
--- a/backend/typescript/services/implementations/donationService.ts
+++ b/backend/typescript/services/implementations/donationService.ts
@@ -26,6 +26,9 @@ class DonationService implements IDonationService {
         where: {
           user_id: userId,
         },
+        include: {
+          cause: true,
+        },
       });
 
       return userDonations;

--- a/frontend/src/components/pages/DashboardPage.tsx
+++ b/frontend/src/components/pages/DashboardPage.tsx
@@ -32,7 +32,7 @@ const DashboardPage = (): React.ReactElement => {
 
       // Transforms fetched data to match table.
       const transformedData = response.data.map((donation: any) => ({
-        Cause: donation.cause_id,
+        Cause: donation.cause.name,
         Date: new Date(donation.donation_date),
         Amount: donation.amount,
         Frequency: donation.is_recurring,


### PR DESCRIPTION
No notion ticket


1. Changed dashboard page to read in donation.cause.name instead of donation.cause_id
2. Changed donationServices.ts  (getUserDonations function) to include cause parameter (previously did not - include deeply nested model field)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Inject dummy data in prisma and check the dashboard page.


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* N/A
* No linting - might be some differences


## Checklist
- [y] My PR name is descriptive and in imperative tense
- [y] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [y] I have run the appropriate linter(s)
- [y] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
